### PR TITLE
Bump to actions/cache@v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
       run: echo "cargohome=${CARGO_HOME:-$HOME/.cargo}" >> $GITHUB_OUTPUT
       shell: bash
       id: cargo-home
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache
       with:
         path: |


### PR DESCRIPTION
Node16.x is deprecated, so bump to newer version.