### PR TITLE
Use actions/cache@v3, not v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
       run: echo "cargohome=${CARGO_HOME:-$HOME/.cargo}" >> $GITHUB_OUTPUT
       shell: bash
       id: cargo-home
-    - uses: actions/cache@v4
+    - uses: actions/cache@v3
       id: cache
       with:
         path: |


### PR DESCRIPTION
I'm not sure how the PR that changed this passed, but AFAICT there's no v4 of `actions/cache`. The latest major version is `v3`.

See https://github.com/houseabsolute/ubi/actions/runs/6726958223/job/18284066779 for an example failure.