### PR TITLE
Add optional input for Cargo lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Setting `denyWarnings` to true will also enable these warnings, but each warning
 | -------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | `TOKEN`        | The GitHub access token to allow us to retrieve, create and update issues (automatically set).   | `github.token`                                                           |
 | `denyWarnings` | Any warnings generated will be treated as an error and fail the action.                          | false                                                                    |
+| `file`         | The path to the Cargo.lock file.                                                                 | `Cargo.lock`                                                             |
 | `ignore`       | A comma separated list of Rustsec IDs to ignore.                                                 |                                                                          |
 | `createIssues` | Create/Update issues for each found vulnerability. By default only on `main` or `master` branch. | `github.ref == 'refs/heads/master' \|\| github.ref == 'refs/heads/main'` |
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Any warnings generated will be treated as an error and fail the action"
     required: false
     default: "false"
+  file:
+    description: "Cargo lockfile to inspect"
+    required: false
+    default: "Cargo.lock"
   ignore:
     description: "A comma separated list of Rustsec IDs to ignore"
     required: false
@@ -52,6 +56,7 @@ runs:
       env:
         INPUT_CREATE_ISSUES: ${{ inputs.createIssues }}
         INPUT_DENY_WARNINGS: ${{ inputs.denyWarnings }}
+        INPUT_FILE: ${{ inputs.file }}
         INPUT_IGNORE: ${{ inputs.ignore }}
         INPUT_TOKEN: ${{ inputs.TOKEN }}
         PYTHONPATH: ${{ github.action_path }}

--- a/audit.py
+++ b/audit.py
@@ -398,6 +398,10 @@ def run() -> None:
         extra_args.append("--deny")
         extra_args.append("warnings")
 
+    if os.environ["INPUT_FILE"] != "":
+        extra_args.append("--file")
+        extra_args.append(os.environ["INPUT_FILE"])
+
     audit_cmd = ["cargo", "audit", "--json"] + extra_args + ignore_args
     debug(f"Running command: {audit_cmd}")
     completed = subprocess.run(


### PR DESCRIPTION
This adds an optional `file` input to Cargo.lock file. I opted-in on the `file` input since that is the option to cargo-audit.

An option to select what lock file to audit was requested in #2.

---

I'm not sure how to test this, please advice.