### PR TITLE
Update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ on:
   # Run manually
   workflow_dispatch:
 
-permissions: read-all
-
 jobs:
   audit:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The write permission on issues in the job sets all other scopes to 'none', including the global 'read-all', so the action failed on code check-out. Instead, set the permission for the job, also reduce it to content since that is all what is required.