### PR TITLE
Fix Run in repositories without `Cargo.lock` checked in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.12] - 2024-01-20
+
+* Fix default of `file` argument to make it work again for repositories without `Cargo.lock` checked in.
+
 ## [1.1.11] - 2024-01-18
 
 * Allow specifying the path to the `Cargo.lock` file, in case it is not in the root of the repository (#55)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Setting `denyWarnings` to true will also enable these warnings, but each warning
 | -------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | `TOKEN`        | The GitHub access token to allow us to retrieve, create and update issues (automatically set).   | `github.token`                                                           |
 | `denyWarnings` | Any warnings generated will be treated as an error and fail the action.                          | false                                                                    |
-| `file`         | The path to the Cargo.lock file.                                                                 | `Cargo.lock`                                                             |
+| `file`         | The path to the Cargo.lock file.                                                                 |                                                                          |
 | `ignore`       | A comma separated list of Rustsec IDs to ignore.                                                 |                                                                          |
 | `createIssues` | Create/Update issues for each found vulnerability. By default only on `main` or `master` branch. | `github.ref == 'refs/heads/master' \|\| github.ref == 'refs/heads/main'` |
 

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   file:
     description: "Cargo lockfile to inspect"
     required: false
-    default: "Cargo.lock"
+    default: ""
   ignore:
     description: "A comma separated list of Rustsec IDs to ignore"
     required: false

--- a/audit.py
+++ b/audit.py
@@ -410,7 +410,9 @@ def run() -> None:
         text=True,
         check=False,
     )
+    debug(f"Command return code: {completed.returncode}")
     debug(f"Command output: {completed.stdout}")
+    debug(f"Command error: {completed.stderr}")
     data = json.loads(completed.stdout)
 
     summary = create_summary(data)


### PR DESCRIPTION
The `file` argument has the wrong default, which breaks in repositories where `Cargo.lock` is missing.