### PR TITLE
Upgrade actions/cache to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       run: echo "cargohome=${CARGO_HOME:-$HOME/.cargo}" >> $GITHUB_OUTPUT
       shell: bash
       id: cargo-home
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: cache
       with:
         path: |


### PR DESCRIPTION
Same as https://github.com/actions-rust-lang/audit/pull/50
Which was reverted in https://github.com/actions-rust-lang/audit/pull/52

`actions/cache@v4` is real now: https://github.com/actions/cache/releases/tag/v4.0.0