### PR TITLE
feat: add --locked to cargo install cargo-audit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Install cargo-audit
       if: steps.cache.outputs.cache-hit != 'true'
       # Update both this version number and the cache key
-      run: cargo install cargo-audit --vers 0.20.0 --no-default-features
+      run: cargo install cargo-audit --vers 0.20.0 --no-default-features --locked
       shell: bash
 
     - run: |


### PR DESCRIPTION
For current `cargo-audit` v0.20.0, building without `--locked` resulted in the failure of `cargo audit` command.
Such buggy `cargo-audit` build will shows error like:
```
cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
error: couldn't fetch advisory database: git operation failed: failed to prepare fetch: An IO error occurred when talking to the server
```

It caused our CI using this action failed: https://github.com/dfinity/sdk/actions/runs/8391495630/job/22997036128.

There must be some dependency of `cargo-audit` have new minor/patch release that is broken.

Adding `--locked` can make sure that all the dependencies are at the versions when `cargo-audit` release v0.20.0.
This is the common practice to for dealing with `bin` crate.
